### PR TITLE
chore: release v0.1.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.3](https://github.com/RileyLeff/floco/compare/v0.1.2...v0.1.3) - 2024-09-07
+
+### Removed
+- removed stupid floatd dependency
+- removed floatd
+
 ## [0.1.2](https://github.com/RileyLeff/floco/compare/v0.1.1...v0.1.2) - 2024-05-19
 
 ### Other

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -43,7 +43,7 @@ checksum = "7a81dae078cea95a014a339291cec439d2f232ebe854a9d672b796c6afafa9b7"
 
 [[package]]
 name = "floco"
-version = "0.1.2"
+version = "0.1.3"
 dependencies = [
  "half",
  "num-traits",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "floco"
-version = "0.1.2"
+version = "0.1.3"
 edition = "2021"
 description = "Floco validates floats against constraints."
 documentation = "https://docs.rs/floco/latest/floco/index.html"


### PR DESCRIPTION
## 🤖 New release
* `floco`: 0.1.2 -> 0.1.3

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.1.3](https://github.com/RileyLeff/floco/compare/v0.1.2...v0.1.3) - 2024-09-07

### Removed
- removed stupid floatd dependency
- removed floatd
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).